### PR TITLE
Prefer toolchain installed `docc` when available

### DIFF
--- a/bin/rundocc
+++ b/bin/rundocc
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+function rundocc() {
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun docc "$@"
+  else
+    docc "$@"
+  fi
+}
+
+rundocc "$@"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test:unit": "vue-cli-service test:unit",
     "test:unit:watch": "vue-cli-service test:unit --watch",
     "lint": "vue-cli-service lint",
-    "docs:preview": "docc preview ./SwiftDocCRender.docc",
-    "docs:build": "docc convert ./SwiftDocCRender.docc"
+    "docs:preview": "bin/rundocc preview SwiftDocCRender.docc",
+    "docs:build": "bin/rundocc convert SwiftDocCRender.docc"
   },
   "files": [
     "src",


### PR DESCRIPTION
For previewing docs, the `rundocc` wrapper script will first try `xcrun docc` to see if a toolchain provided tool can be used  while still falling back to any available `docc` binary found in `$PATH` otherwise. This should reduce a little friction to preview docs for many users who haven't manually built Swift-DocC themselves.

Note: this will only be useful for developers on macOS with Xcode installed, but it should still be a slight improvement over just relying on `docc` itself.