### PR TITLE
Hide new navigator UX behind a feature flag

### DIFF
--- a/app/public/theme-settings.json
+++ b/app/public/theme-settings.json
@@ -53,6 +53,9 @@
     "docs": {
       "summary": {
         "hide": false
+      },
+      "navigator": {
+        "enable": false
       }
     }
   }

--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -49,7 +49,7 @@ import { waitFrames } from 'docc-render/utils/loading';
 import scrollLock from 'docc-render/utils/scroll-lock';
 import FocusTrap from 'docc-render/utils/FocusTrap';
 import changeElementVOVisibility from 'docc-render/utils/changeElementVOVisibility';
-import throttle from '@/utils/throttle';
+import throttle from 'docc-render/utils/throttle';
 
 export const STORAGE_KEY = 'sidebar';
 

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -26,7 +26,7 @@
         @toggle-sidenav="isSideNavOpen = !isSideNavOpen"
       />
       <component
-        :is="isTargetIDE ? 'div': 'AdjustableSidebarWidth'"
+        :is="enableNavigator ? 'AdjustableSidebarWidth' : 'div'"
         v-bind="sidebarProps"
         v-on="sidebarListeners"
       >
@@ -224,11 +224,12 @@ export default {
           && platforms.every(platform => platform.deprecatedAt)
         )
       ),
-    sidebarProps: ({ isSideNavOpen, isTargetIDE }) => (isTargetIDE ? {} : { class: 'full-width-container', openExternally: isSideNavOpen }),
+    enableNavigator: () => false,
+    sidebarProps: ({ isSideNavOpen, enableNavigator }) => (enableNavigator ? { class: 'full-width-container', openExternally: isSideNavOpen } : {}),
     sidebarListeners() {
-      return this.isTargetIDE ? {} : {
+      return this.enableNavigator ? ({
         'update:openExternally': (v) => { this.isSideNavOpen = v; },
-      };
+      }) : {};
     },
   },
   methods: {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -64,6 +64,7 @@
 
 <script>
 import { apply } from 'docc-render/utils/json-patch';
+import { getSetting } from 'docc-render/utils/theme-settings';
 import {
   clone,
   fetchDataForRouteEnter,
@@ -224,7 +225,12 @@ export default {
           && platforms.every(platform => platform.deprecatedAt)
         )
       ),
-    enableNavigator: () => false,
+    // Always disable the navigator for IDE targets. For other targets, allow
+    // this feature to be enabled through the `features.docs.navigator.enable`
+    // setting in `theme-settings.json`
+    enableNavigator: ({ isTargetIDE }) => !isTargetIDE && (
+      getSetting(['features', 'docs', 'navigator', 'enable'], false)
+    ),
     sidebarProps: ({ isSideNavOpen, enableNavigator }) => (enableNavigator ? { class: 'full-width-container', openExternally: isSideNavOpen } : {}),
     sidebarListeners() {
       return this.enableNavigator ? ({

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -10,6 +10,7 @@
 
 import * as dataUtils from 'docc-render/utils/data';
 import { shallowMount } from '@vue/test-utils';
+import { getSetting } from 'docc-render/utils/theme-settings';
 import DocumentationTopic from 'docc-render/views/DocumentationTopic.vue';
 import DocumentationTopicStore from 'docc-render/stores/DocumentationTopicStore';
 import onPageLoadScrollToFragment from 'docc-render/mixins/onPageLoadScrollToFragment';
@@ -23,6 +24,14 @@ jest.mock('docc-render/mixins/onPageLoadScrollToFragment');
 jest.mock('docc-render/utils/FocusTrap');
 jest.mock('docc-render/utils/changeElementVOVisibility');
 jest.mock('docc-render/utils/scroll-lock');
+jest.mock('docc-render/utils/theme-settings');
+
+const defaultGetSetting = (_, fallback) => fallback;
+const getSettingWithNavigatorEnabled = (settingKeyPath, fallback) => (
+  (settingKeyPath.join('.') === 'features.docs.navigator.enable') || fallback
+);
+
+getSetting.mockImplementation(defaultGetSetting);
 
 const TechnologyWithChildren = {
   path: 'path/to/foo',
@@ -130,7 +139,9 @@ describe('DocumentationTopic', () => {
     expect(codeTheme.isEmpty()).toBe(true);
   });
 
-  it('renders the Navigator and AdjustableSidebarWidth', async () => {
+  it('renders the Navigator and AdjustableSidebarWidth when enabled', async () => {
+    getSetting.mockImplementation(getSettingWithNavigatorEnabled);
+
     wrapper.setData({ topicData });
     expect(wrapper.find(AdjustableSidebarWidth).props()).toEqual({
       openExternally: false,
@@ -160,6 +171,8 @@ describe('DocumentationTopic', () => {
       references: topicData.references,
       technology: TechnologyWithChildren,
     });
+
+    getSetting.mockReset();
   });
 
   it('renders a `Nav` component', () => {
@@ -186,6 +199,8 @@ describe('DocumentationTopic', () => {
   });
 
   it('handles the `@close`, on Navigator', async () => {
+    getSetting.mockImplementation(getSettingWithNavigatorEnabled);
+
     wrapper.setData({ topicData });
     await flushPromises();
     const nav = wrapper.find(Nav);
@@ -195,6 +210,8 @@ describe('DocumentationTopic', () => {
     await flushPromises();
     wrapper.find(Navigator).vm.$emit('close');
     expect(sidebar.props('openExternally')).toBe(false);
+
+    getSetting.mockReset();
   });
 
   it('renders a `Topic` with `topicData`', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 89108699

## Summary

This is a slight update to https://github.com/apple/swift-docc-render/pull/51 that disables/hides the new navigator UX by default and provides a feature flag in `theme-settings.json` that allows opting in to this new functionality.

\cc @ethan-kusters @hqhhuang

## Dependencies

https://github.com/apple/swift-docc-render/pull/51

## Testing

Steps:
1. Run `npm run serve` and observe that the navigator is not enabled by default.
2. Change `features.docs.navigator.enable` in `theme-settings.json` from `false` to `true` and observe that the navigator UX is enabled on subsequent page visits/refreshes.