### PR TITLE
New Hero/Introduction section design: Left Align Hero Content

### DIFF
--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -55,10 +55,14 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   background: dark-color(fill);
   color: light-color(fill);
   overflow: hidden;
-  text-align: center;
+  text-align: left;
   padding-top: rem(40px);
   padding-bottom: 40px;
   position: relative;
+
+  @include breakpoint(small) {
+    text-align: center;
+  }
 
   // gradient
   &:before {

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -332,11 +332,17 @@ $breakpoint-attributes: (
     padding: 0 20px;
     box-sizing: border-box;
 
-    // make sure there is 120px space around the content on xlarge
-    @include breakpoints-from(xlarge) {
+    // make sure there is 120px space between the content and nav bar on xl and l
+    @include breakpoints-from(large) {
       box-sizing: unset;
       padding-right: 120px;
       padding-left: 120px;
+      margin-left: 0px;
+    }
+
+    @include breakpoint(medium) {
+      padding-right: 80px;
+      padding-left: 80px;
     }
   }
   @include inTargetIde {

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -329,22 +329,24 @@ $breakpoint-attributes: (
     min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
-    padding: 0 20px;
+    padding-left: 80px;
+    padding-right: 80px;
     box-sizing: border-box;
 
     // make sure there is 120px space between the content and nav bar on xl and l
     @include breakpoints-from(large) {
       box-sizing: unset;
-      padding-right: 120px;
       padding-left: 120px;
+      padding-right: 120px;
       margin-left: 0px;
     }
 
-    @include breakpoint(medium) {
-      padding-right: 80px;
-      padding-left: 80px;
+    @include breakpoint(small) {
+      padding-left: 20px;
+      padding-right: 20px;
     }
   }
+
   @include inTargetIde {
     @include breakpoint-content()
   }


### PR DESCRIPTION
Bug/issue #, if applicable: 89970021

## Summary
Based on the new design of the hero/introduction section:
Content in Hero:
1. Content in the Hero should be left-aligned in medium or larger viewports
2. Content in the Hero should be centered in small viewport

Update spacing for body content:
1. In large and extra large viewports: padding left and right of the body content should be 120px (plus extra on the right only if the viewport is wide enough)
2. In medium viewport: padding left and right of body content should be 80px (plus extra on the left and right, if the viewport is wide enough)
3. In small viewport: padding left and right of body content should be 20px.
![Default-Theme-Specs](https://user-images.githubusercontent.com/87735557/157558846-be0409e7-4c5d-4b04-86db-d4c038e973a9.png)


## Testing
Steps:
1. run this branch
2. test the page in different view port sizes and verify that it fits the above description.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA