### PR TITLE
New Hero/Introduction section design: Remove Dark Hero from symbol pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -11,7 +11,7 @@
 <template>
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
-      <DocumentationHero :type="symbolKind || role" :enableHero="enableHero">
+      <DocumentationHero :type="symbolKind || role" :enhanceBackground="enhanceBackground">
         <slot name="above-title" />
         <Title :eyebrow="roleHeading" :style=heroTitleStyle>{{ title }}</Title>
         <Abstract v-if="abstract" :content="abstract" />
@@ -301,17 +301,17 @@ export default {
     ),
     shouldShowLanguageSwitcher: ({ objcPath, swiftPath }) => objcPath && swiftPath,
     hideSummary: () => getSetting(['features', 'docs', 'summary', 'hide'], false),
-    enableHero: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
-    heroTitleStyle({ enableHero }) {
-      return enableHero ? {
-        '--hero-eyebrow': 'light-color(figure-gray-secondary)',
-        '--hero-title': 'light-color(fill)',
+    enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
+    heroTitleStyle({ enhanceBackground }) {
+      return enhanceBackground ? {
+        '--hero-eyebrow-color': 'light-color(figure-gray-secondary)',
+        '--hero-title-color': 'light-color(fill)',
       } : {
-        '--hero-eyebrow': 'var(--colors-secondary-label,var(--color-secondary-label))',
+        '--hero-eyebrow-color': 'var(--colors-secondary-label,var(--color-secondary-label))',
       };
     },
-    borderWidth({ enableHero }) {
-      return enableHero ? {
+    borderWidth({ enhanceBackground }) {
+      return enhanceBackground ? {
         '--border-width': '0px',
       } : {
         '--border-width': '1px',

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -11,9 +11,9 @@
 <template>
   <div class="doc-topic">
     <main class="main" id="main" role="main" tabindex="0">
-      <DocumentationHero :type="symbolKind || role">
+      <DocumentationHero :type="symbolKind || role" :enableHero="enableHero">
         <slot name="above-title" />
-        <Title :eyebrow="roleHeading">{{ title }}</Title>
+        <Title :eyebrow="roleHeading" :style=heroTitleStyle>{{ title }}</Title>
         <Abstract v-if="abstract" :content="abstract" />
       </DocumentationHero>
       <div class="container content-grid" :class="{ 'full-width': hideSummary }">
@@ -54,6 +54,7 @@
           v-if="primaryContentSections && primaryContentSections.length"
           :conformance="conformance"
           :sections="primaryContentSections"
+          :style="borderWidth"
         />
       </div>
       <Topics
@@ -300,6 +301,22 @@ export default {
     ),
     shouldShowLanguageSwitcher: ({ objcPath, swiftPath }) => objcPath && swiftPath,
     hideSummary: () => getSetting(['features', 'docs', 'summary', 'hide'], false),
+    enableHero: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
+    heroTitleStyle({ enableHero }) {
+      return enableHero ? {
+        '--hero-eyebrow': 'light-color(figure-gray-secondary)',
+        '--hero-title': 'light-color(fill)',
+      } : {
+        '--hero-eyebrow': 'var(--colors-secondary-label,var(--color-secondary-label))',
+      };
+    },
+    borderWidth({ enableHero }) {
+      return enableHero ? {
+        '--border-width': '0px',
+      } : {
+        '--border-width': '1px',
+      };
+    },
   },
   methods: {
     normalizePath(path) {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -13,7 +13,7 @@
     <main class="main" id="main" role="main" tabindex="0">
       <DocumentationHero :type="symbolKind || role" :enhanceBackground="enhanceBackground">
         <slot name="above-title" />
-        <Title :eyebrow="roleHeading" :style=heroTitleStyle>{{ title }}</Title>
+        <Title :eyebrow="roleHeading">{{ title }}</Title>
         <Abstract v-if="abstract" :content="abstract" />
       </DocumentationHero>
       <div class="container content-grid" :class="{ 'full-width': hideSummary }">
@@ -302,14 +302,6 @@ export default {
     shouldShowLanguageSwitcher: ({ objcPath, swiftPath }) => objcPath && swiftPath,
     hideSummary: () => getSetting(['features', 'docs', 'summary', 'hide'], false),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
-    heroTitleStyle({ enhanceBackground }) {
-      return enhanceBackground ? {
-        '--hero-eyebrow-color': 'light-color(figure-gray-secondary)',
-        '--hero-title-color': 'light-color(fill)',
-      } : {
-        '--hero-eyebrow-color': 'var(--colors-secondary-label,var(--color-secondary-label))',
-      };
-    },
     borderWidth({ enhanceBackground }) {
       return enhanceBackground ? {
         '--border-width': '0px',

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -52,9 +52,9 @@
         </Summary>
         <PrimaryContent
           v-if="primaryContentSections && primaryContentSections.length"
+          :class="{ 'with-border': !enhanceBackground }"
           :conformance="conformance"
           :sections="primaryContentSections"
-          :style="borderWidth"
         />
       </div>
       <Topics
@@ -302,13 +302,6 @@ export default {
     shouldShowLanguageSwitcher: ({ objcPath, swiftPath }) => objcPath && swiftPath,
     hideSummary: () => getSetting(['features', 'docs', 'summary', 'hide'], false),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
-    borderWidth({ enhanceBackground }) {
-      return enhanceBackground ? {
-        '--border-width': '0px',
-      } : {
-        '--border-width': '1px',
-      };
-    },
   },
   methods: {
     normalizePath(path) {

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -146,11 +146,11 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   color: var(--colors-text, var(--color-text));
 
   &:before {
-    background: none;
+    content: none;
   }
 
   &:after {
-    background: none;
+    content: none;
   }
 }
 </style>

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -66,7 +66,7 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
 
 .documentation-hero {
   background: dark-color(fill);
-  color: light-color(fill);
+  color: dark-color(figure-gray);
   overflow: hidden;
   text-align: left;
   padding-top: rem(40px);
@@ -143,8 +143,7 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
 
 .documentation-hero--disabled {
   background: none;
-  color: dark-color(fill);
-  --hero-eyebrow-color: var(--colors-secondary-label,var(--color-secondary-label));
+  color: var(--colors-text, var(--color-text));
 
   &:before {
     background: none;

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -37,6 +37,10 @@ export default {
       type: String,
       required: true,
     },
+    enableHero: {
+      type: Boolean,
+      required: true,
+    },
   },
   computed: {
     // get the alias, if any, and fallback to the `teal` color
@@ -45,7 +49,6 @@ export default {
       // use the color or fallback to the gray secondary, if not defined.
       '--accent-color': `var(--color-type-icon-${color}, var(--color-figure-gray-secondary))`,
     }),
-    enableHero: ({ type }) => (!(type === 'symbol' || type === 'protocol')),
     heroClass: ({ enableHero }) => (enableHero ? 'documentation-hero' : 'documentation-hero-disabled'),
   },
 };
@@ -60,12 +63,15 @@ $doc-hero-icon-opacity: 1 !default;
 $doc-hero-icon-color: dark-color(fill-secondary) !default;
 
 .documentation-hero-disabled {
-  color: var(--colors-secondary-label, var(--color-secondary-label));
   overflow: hidden;
-  text-align: center;
+  text-align: left;
   padding-top: rem(40px);
   padding-bottom: 40px;
   position: relative;
+
+  @include breakpoint(small) {
+    text-align: center;
+  }
 }
 
 .documentation-hero {

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -9,13 +9,16 @@
 -->
 
 <template>
-  <div :class=heroClass :style="styles">
+  <div
+    :class="['documentation-hero', { 'documentation-hero--disabled': !enhanceBackground }]"
+    :style="styles"
+  >
     <NavigatorLeafIcon
-      v-if="enableHero" :type="type"
+      v-if="enhanceBackground" :type="type"
       key="first" class="background-icon first-icon" with-colors
     />
     <NavigatorLeafIcon
-      v-if="enableHero" :type="type"
+      v-if="enhanceBackground" :type="type"
       key="second" class="background-icon second-icon" with-colors
     />
     <div class="documentation-hero__content">
@@ -37,7 +40,7 @@ export default {
       type: String,
       required: true,
     },
-    enableHero: {
+    enhanceBackground: {
       type: Boolean,
       required: true,
     },
@@ -49,7 +52,6 @@ export default {
       // use the color or fallback to the gray secondary, if not defined.
       '--accent-color': `var(--color-type-icon-${color}, var(--color-figure-gray-secondary))`,
     }),
-    heroClass: ({ enableHero }) => (enableHero ? 'documentation-hero' : 'documentation-hero-disabled'),
   },
 };
 </script>
@@ -61,18 +63,6 @@ $doc-hero-gradient-background: dark-color(fill-tertiary) !default;
 $doc-hero-overlay-background: transparent !default;
 $doc-hero-icon-opacity: 1 !default;
 $doc-hero-icon-color: dark-color(fill-secondary) !default;
-
-.documentation-hero-disabled {
-  overflow: hidden;
-  text-align: left;
-  padding-top: rem(40px);
-  padding-bottom: 40px;
-  position: relative;
-
-  @include breakpoint(small) {
-    text-align: center;
-  }
-}
 
 .documentation-hero {
   background: dark-color(fill);
@@ -148,6 +138,19 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
     position: relative;
     z-index: 1;
     @include dynamic-content-container;
+  }
+}
+
+.documentation-hero--disabled {
+  background: none;
+  color: initial;
+
+  &:before {
+    background: none;
+  }
+
+  &:after {
+    background: none;
   }
 }
 </style>

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -9,9 +9,15 @@
 -->
 
 <template>
-  <div class="documentation-hero" :style="styles">
-    <NavigatorLeafIcon :type="type" key="first" class="background-icon first-icon" with-colors />
-    <NavigatorLeafIcon :type="type" key="second" class="background-icon second-icon" with-colors />
+  <div :class=heroClass :style="styles">
+    <NavigatorLeafIcon
+      v-if="enableHero" :type="type"
+      key="first" class="background-icon first-icon" with-colors
+    />
+    <NavigatorLeafIcon
+      v-if="enableHero" :type="type"
+      key="second" class="background-icon second-icon" with-colors
+    />
     <div class="documentation-hero__content">
       <slot />
     </div>
@@ -39,6 +45,8 @@ export default {
       // use the color or fallback to the gray secondary, if not defined.
       '--accent-color': `var(--color-type-icon-${color}, var(--color-figure-gray-secondary))`,
     }),
+    enableHero: ({ type }) => (!(type === 'symbol' || type === 'protocol')),
+    heroClass: ({ enableHero }) => (enableHero ? 'documentation-hero' : 'documentation-hero-disabled'),
   },
 };
 </script>
@@ -50,6 +58,15 @@ $doc-hero-gradient-background: dark-color(fill-tertiary) !default;
 $doc-hero-overlay-background: transparent !default;
 $doc-hero-icon-opacity: 1 !default;
 $doc-hero-icon-color: dark-color(fill-secondary) !default;
+
+.documentation-hero-disabled {
+  color: var(--colors-secondary-label, var(--color-secondary-label));
+  overflow: hidden;
+  text-align: center;
+  padding-top: rem(40px);
+  padding-bottom: 40px;
+  position: relative;
+}
 
 .documentation-hero {
   background: dark-color(fill);

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -143,7 +143,8 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
 
 .documentation-hero--disabled {
   background: none;
-  color: initial;
+  color: dark-color(fill);
+  --hero-eyebrow-color: var(--colors-secondary-label,var(--color-secondary-label));
 
   &:before {
     background: none;

--- a/src/components/DocumentationTopic/PrimaryContent.vue
+++ b/src/components/DocumentationTopic/PrimaryContent.vue
@@ -150,10 +150,10 @@ export default {
 }
 
 .primary-content {
-  &::before {
+  &.with-border::before {
     border-top-color: var(--colors-grid, var(--color-grid));
     border-top-style: solid;
-    border-top-width: var(--border-width);
+    border-top-width: 1px;
     content: '';
     display: block;
   }

--- a/src/components/DocumentationTopic/PrimaryContent.vue
+++ b/src/components/DocumentationTopic/PrimaryContent.vue
@@ -153,7 +153,7 @@ export default {
   &::before {
     border-top-color: var(--colors-grid, var(--color-grid));
     border-top-style: solid;
-    border-top-width: 1px;
+    border-top-width: var(--border-width);
     content: '';
     display: block;
   }

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -35,13 +35,14 @@ export default {
 
 .eyebrow {
   @include font-styles(eyebrow-reduced);
+  color: var(--hero-eyebrow);
   display: block;
   margin-bottom: rem(20px);
 }
 
 .title {
   @include font-styles(headline-reduced);
-  color: light-color(fill);
+  color: var(--hero-title);
   margin-bottom: rem(12px);
 }
 </style>

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -35,14 +35,22 @@ export default {
 
 .eyebrow {
   @include font-styles(eyebrow-reduced);
-  color: var(--hero-eyebrow-color);
+  color: dark-color(figure-gray-secondary);
   display: block;
   margin-bottom: rem(20px);
+
+  .documentation-hero--disabled & {
+    color: var(--colors-secondary-label, var(--color-secondary-label));
+  }
 }
 
 .title {
   @include font-styles(headline-reduced);
-  color: var(--hero-title-color);
+  color: dark-color(figure-gray);
   margin-bottom: rem(12px);
+
+  .documentation-hero--disabled & {
+    color: var(--colors-header-text, var(--color-header-text));
+  }
 }
 </style>

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -35,7 +35,6 @@ export default {
 
 .eyebrow {
   @include font-styles(eyebrow-reduced);
-  color: light-color(fill-gray-tertiary);
   display: block;
   margin-bottom: rem(20px);
 }

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -35,14 +35,14 @@ export default {
 
 .eyebrow {
   @include font-styles(eyebrow-reduced);
-  color: var(--hero-eyebrow);
+  color: var(--hero-eyebrow-color);
   display: block;
   margin-bottom: rem(20px);
 }
 
 .title {
   @include font-styles(headline-reduced);
-  color: var(--hero-title);
+  color: var(--hero-title-color);
   margin-bottom: rem(12px);
 }
 </style>

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -330,7 +330,6 @@ $breakpoint-attributes: (
     min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
-    margin-top: 0;
     padding-left: 80px;
     padding-right: 80px;
     box-sizing: border-box;

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -147,6 +147,7 @@ $breakpoint-attributes: (
   // Center the content using auto left/right margins
   margin-left: auto;
   margin-right: auto;
+  margin-top: 0;
 
   @each $breakpoint, $attributes in $breakpoints {
     $min-width: map-deep-get($breakpoints, ($breakpoint, min-width));
@@ -329,6 +330,7 @@ $breakpoint-attributes: (
     min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
+    margin-top: 0;
     padding-left: 80px;
     padding-right: 80px;
     box-sizing: border-box;

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -147,7 +147,6 @@ $breakpoint-attributes: (
   // Center the content using auto left/right margins
   margin-left: auto;
   margin-right: auto;
-  margin-top: 0;
 
   @each $breakpoint, $attributes in $breakpoints {
     $min-width: map-deep-get($breakpoints, ($breakpoint, min-width));

--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -329,6 +329,7 @@ $breakpoint-attributes: (
     min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
+    margin-top: 0;
     padding: 0 20px;
     box-sizing: border-box;
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -208,7 +208,7 @@ describe('DocumentationTopic', () => {
   it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
-    expect(hero.props()).toEqual({ type: propsData.symbolKind, enableHero: true });
+    expect(hero.props()).toEqual({ type: propsData.symbolKind, enhanceBackground: true });
   });
 
   it('renders a `DocumentationHero`, enabled, with a the `role`, if no symbolKind', () => {
@@ -217,7 +217,7 @@ describe('DocumentationTopic', () => {
       symbolKind: '',
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.article, enableHero: true });
+    expect(hero.props()).toEqual({ type: TopicTypes.article, enhanceBackground: true });
   });
 
   it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
@@ -226,7 +226,7 @@ describe('DocumentationTopic', () => {
       symbolKind: 'module',
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.module, enableHero: true });
+    expect(hero.props()).toEqual({ type: TopicTypes.module, enhanceBackground: true });
   });
 
   it('render a `DocumentationHero`, disabled, if symbol page', () => {
@@ -234,7 +234,7 @@ describe('DocumentationTopic', () => {
       symbolKind: 'protocol',
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.protocol, enableHero: false });
+    expect(hero.props()).toEqual({ type: TopicTypes.protocol, enhanceBackground: false });
   });
 
   it('renders a `Title`', () => {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -205,19 +205,36 @@ describe('DocumentationTopic', () => {
     expect(main.attributes('tabindex')).toBe('0');
   });
 
-  it('renders a `DocumentationHero`', () => {
+  it('renders a `DocumentationHero`, enabled', () => {
     const hero = wrapper.find(DocumentationHero);
     expect(hero.exists()).toBe(true);
-    expect(hero.props()).toEqual({ type: propsData.symbolKind });
+    expect(hero.props()).toEqual({ type: propsData.symbolKind, enableHero: true });
   });
 
-  it('renders a `DocumentationHero`, with a the `role`, if no symbolKind', () => {
+  it('renders a `DocumentationHero`, enabled, with a the `role`, if no symbolKind', () => {
     wrapper.setProps({
       role: TopicTypes.article,
       symbolKind: '',
     });
     const hero = wrapper.find(DocumentationHero);
-    expect(hero.props()).toEqual({ type: TopicTypes.article });
+    expect(hero.props()).toEqual({ type: TopicTypes.article, enableHero: true });
+  });
+
+  it('render a `DocumentationHero`, enabled, if top-level technology page', () => {
+    wrapper.setProps({
+      role: TopicTypes.collection,
+      symbolKind: 'module',
+    });
+    const hero = wrapper.find(DocumentationHero);
+    expect(hero.props()).toEqual({ type: TopicTypes.module, enableHero: true });
+  });
+
+  it('render a `DocumentationHero`, disabled, if symbol page', () => {
+    wrapper.setProps({
+      symbolKind: 'protocol',
+    });
+    const hero = wrapper.find(DocumentationHero);
+    expect(hero.props()).toEqual({ type: TopicTypes.protocol, enableHero: false });
   });
 
   it('renders a `Title`', () => {

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -20,7 +20,7 @@ import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 
 const defaultProps = {
   type: TopicTypes.class,
-  enableHero: true,
+  enhanceBackground: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -78,7 +78,7 @@ describe('DocumentationHero', () => {
   it('renders the DocumentationHero, disabled', () => {
     const wrapper = createWrapper();
     wrapper.setProps({
-      enableHero: false,
+      enhanceBackground: false,
     });
     // assert no icon
     const allIcons = wrapper.findAll(NavigatorLeafIcon);

--- a/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationHero.spec.js
@@ -20,6 +20,7 @@ import NavigatorLeafIcon from '@/components/Navigator/NavigatorLeafIcon.vue';
 
 const defaultProps = {
   type: TopicTypes.class,
+  enableHero: true,
 };
 
 const createWrapper = ({ propsData, ...others } = {}) => shallowMount(DocumentationHero, {
@@ -34,7 +35,7 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(Documentat
 });
 
 describe('DocumentationHero', () => {
-  it('renders the DocumentationHero', () => {
+  it('renders the DocumentationHero, enabled', () => {
     const wrapper = createWrapper();
     const allIcons = wrapper.findAll(NavigatorLeafIcon);
     expect(allIcons).toHaveLength(2);
@@ -71,6 +72,21 @@ describe('DocumentationHero', () => {
     });
     expect(wrapper.vm.styles).toEqual({
       '--accent-color': `var(--color-type-icon-${TopicTypeColors.teal}, var(--color-figure-gray-secondary))`,
+    });
+  });
+
+  it('renders the DocumentationHero, disabled', () => {
+    const wrapper = createWrapper();
+    wrapper.setProps({
+      enableHero: false,
+    });
+    // assert no icon
+    const allIcons = wrapper.findAll(NavigatorLeafIcon);
+    expect(allIcons).toHaveLength(0);
+    // assert slot
+    expect(wrapper.find('.default-slot').text()).toBe('Default Slot');
+    expect(wrapper.vm.styles).toEqual({
+      '--accent-color': `var(--color-type-icon-${TopicTypeColorsMap[defaultProps.type]}, var(--color-figure-gray-secondary))`,
     });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 89970711, 89691884

## Summary
With the new Hero/Introduction section design, we are removing the dark hero design from symbol pages. This means that only Articles, Sample Code, API Collections, Top-level technology pages should render the dark Hero background. 

This PR also fixes the extra gray divider line that was between the Hero and body content.

## Testing
Steps:
1. Run this branch
2. Assert that only Articles, Sample Code, API Collections, Top-level technology pages have dark hero design. 
![Default-Theme-Specs](https://user-images.githubusercontent.com/87735557/157776539-858fc432-5aed-4354-a7f9-21548955e52b.png)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
