### PR TITLE
Properly hide items when "Hide Deprecated" is picked

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -55,6 +55,9 @@ import { BreakpointName } from 'docc-render/utils/breakpoints';
  * @property {array} abstract - symbol abstract
  * @property {string} path - path to page, used in navigation
  * @property {number} parent - parent UID
+ * @property {number} groupMarkerUID - UID of the groupMarker that labels this
+ * @property {number} deprecatedChildrenCount - number of children that are deprecated.
+ * Used for filtering
  * @property {number} depth - depth of symbol in original tree
  * @property {number} index - index of item in siblings
  * @property {number} siblingsCount - number of siblings
@@ -189,10 +192,17 @@ export default {
         node.parent = parentUID;
         // store the current groupMarker reference
         if (node.type === TopicTypes.groupMarker) {
+          node.deprecatedChildrenCount = 0;
           groupMarkerNode = node;
         } else if (groupMarkerNode) {
           // push the current node to the group marker before it
           groupMarkerNode.childUIDs.push(node.uid);
+          // store the groupMarker UID for each item
+          node.groupMarkerUID = groupMarkerNode.uid;
+          if (node.deprecated) {
+            // count deprecated children, so we can hide the entire group when filtering
+            groupMarkerNode.deprecatedChildrenCount += 1;
+          }
         }
         // store which item it is
         node.index = index;

--- a/src/components/Navigator/NavigatorCard.vue
+++ b/src/components/Navigator/NavigatorCard.vue
@@ -380,8 +380,10 @@ export default {
       const tagsSet = new Set(selectedTags);
       // find children that match current filters
       return children.filter(({
-        title, path, type, deprecated,
+        title, path, type, deprecated, deprecatedChildrenCount, childUIDs,
       }) => {
+        // groupMarkers know how many children they have and how many are deprecated
+        const isDeprecated = deprecated || deprecatedChildrenCount === childUIDs.length;
         // check if `title` matches the pattern, if provided
         const titleMatch = filterPattern ? filterPattern.test(title) : true;
         // check if `type` matches any of the selected tags
@@ -392,7 +394,7 @@ export default {
           if (apiChanges && !tagMatch) {
             tagMatch = tagsSet.has(apiChangesObject[path]);
           }
-          if (!deprecated && tagsSet.has(HIDE_DEPRECATED_TAG)) {
+          if (!isDeprecated && tagsSet.has(HIDE_DEPRECATED_TAG)) {
             tagMatch = true;
           }
         }
@@ -406,8 +408,9 @@ export default {
      * Returns a Set of all nodes that match a filter, along with their parents.
      * @returns Set<NavigatorFlatItem>
      */
-    filteredChildrenUpToRootSet: ({ filteredChildren, getParents }) => new Set(
-      filteredChildren.flatMap(({ uid }) => getParents(uid)),
+    filteredChildrenUpToRootSet: ({ filteredChildren, getParents, childrenMap }) => new Set(
+      filteredChildren.flatMap(({ uid, groupMarkerUID }) => getParents(uid)
+        .concat(childrenMap[groupMarkerUID] || [])),
     ),
     /**
      * This generates a map of all the nodes we are allowed to render at a certain time.


### PR DESCRIPTION
Bug/issue #, if applicable: 93506254

## Summary

Fixes issues with labels being shown when "Hide Deprecated" is picked.

## Dependencies

NA

## Testing

Steps:
1. Start searching for a Label that has all deprecated items
2. Assert you can see the label
3. Choose "Hide Deprecated" tag
4. Assert the label and children are no longer shown. 
5. Assert there are no empty parents without relation to the search.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
